### PR TITLE
Fix queryRenderedFeatures parameters

### DIFF
--- a/mapbox-gl.d.ts
+++ b/mapbox-gl.d.ts
@@ -40,7 +40,7 @@ declare namespace mapboxgl {
 
 		unproject(point: mapboxgl.Point | number[]): mapboxgl.LngLat;
 
-		queryRenderedFeatures(pointOrBox?: mapboxgl.Point|number[]|mapboxgl.Point[]|number[][], parameters?: {layers?: string[], filter?: any[]}): GeoJSON.Feature<GeoJSON.GeometryObject>[];
+		queryRenderedFeatures(pointOrBoxOrParameters?: mapboxgl.Point|number[]|mapboxgl.Point[]|number[][]|{layers?: string[], filter?: any[]}, parameters?: {layers?: string[], filter?: any[]}): GeoJSON.Feature<GeoJSON.GeometryObject>[];
 
 		querySourceFeatures(sourceID: string, parameters: {sourceLayer?: string, filter?: any[]}): GeoJSON.Feature<GeoJSON.GeometryObject>[];
 


### PR DESCRIPTION
According to [API](https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures), it's possible to call `queryRenderedFeatures` with just `parameters` as the first parameter is optional. Updated the types accordingly.
