### PR TITLE
Make x and y accessible on mapboxgl.Point type

### DIFF
--- a/mapbox-gl.d.ts
+++ b/mapbox-gl.d.ts
@@ -583,6 +583,10 @@ declare namespace mapboxgl {
 		// Todo: Pull out class to seperate definition for Module "point-geometry"
 	export class Point {
 		constructor(options?: Object);
+		
+		x:number;
+		
+		y:number;
 
 		clone(): Point;
 


### PR DESCRIPTION
Make x and y accessible on mapboxgl.Point type

We are using mapbox gl in Norkart, but sometimes have to edit the typescript definitions ourselves. This one was at the core so I think everyone should have a better version.